### PR TITLE
Add shortcuts to docs viewmodes DE+EN

### DIFF
--- a/_webui_collection/DE/Ansichten.md
+++ b/_webui_collection/DE/Ansichten.md
@@ -15,7 +15,7 @@ Sämtliche Fenster (z.B. "Aufträge") öffnen prinzipiell in der Listenansicht. 
 Bei einem Doppelklick auf einen Datensatz oder beim [Neuanlegen eines Datensatzes ](Neuer_Datensatz_Fenster_Webui) wechselt metasfresh automatisch in die Einzelansicht.
 Dort können Datenänderungen vorgenommen werden.
 
-Um von der Einzelansicht wieder zurück in die Listenansicht zu wechseln, brauchst Du nur in dem Navigationsmenü auf den vorherigen Punkt zu klicken.
+Um von der Einzelansicht wieder zurück in die Listenansicht zu wechseln, brauchst Du nur in dem Navigationsmenü auf den vorherigen Punkt zu klicken. Alternativ kannst Du auch den Zurück-Button Deines Internetbrowsers verwenden.
 
 Hier siehst Du, wie Du zwischen Einzel- und Listenansicht hin und her wechseln kannst:
 ![](assets/einzelundlistenansicht.gif)
@@ -23,6 +23,7 @@ Hier siehst Du, wie Du zwischen Einzel- und Listenansicht hin und her wechseln k
 
 ## Erweiterte Erfassung
 Die Einzelansicht zeigt nur die wichtigsten Felder. Um alle weiteren Felder zu sehen und zu bearbeiten, kannst Du über das [Aktionsmenü](AktionStarten) in die "Erweiterte Erfassung" wechseln.
+ > Hinweis: Tastenkombination `Strg + E` verwenden, um in das Fenster "Erweiterte Erfassung" zu wechseln.
 
 Hier siehst Du, wie Du von der Einzelansicht in die Erweiterte Erfassung wechselst:
 

--- a/_webui_collection/EN/ViewModes.md
+++ b/_webui_collection/EN/ViewModes.md
@@ -14,7 +14,7 @@ In general, all windows (e.g. "Sales Order") open up in list view. No edits can 
 ## Detailed view
 When you double-click a record or [create a new record](New_Record_Window), metasfresh automatically switches to the detailed view. Here you can edit your record.
 
-To switch back to the list view, simply go to the Navigation Menu and click on the previous link.
+To switch back to the list view, simply go to the Navigation Menu and click on the previous link. Alternatively you can also use the back button of your web browser.
 
 See here how to switch between detailed view and list view:
 ![](assets/ListAndDetailedView.gif)
@@ -22,6 +22,7 @@ See here how to switch between detailed view and list view:
 
 ## Advanced Edit
 The detailed view only shows the main fields. To see and edit all additional fields, go to the [action menu](StartAction) and click on "Advanced Edit".
+ > Note: Use shortcut `Ctrl + E` to open the Advanced Edit window.
 
 See here how to switch from the detailed view into the Advanced Edit view:
 


### PR DESCRIPTION
Added Keyboard Shortcuts to docs viewmodes for DE and EN as well as
"switch back" alternative (back button web browser).

(metas-ts: this is about issue #107)