### PR TITLE
Documented "Alt + ENTER" to apply filter

### DIFF
--- a/_webui_collection/DE/Liste_Keyboard_Shortcuts.md
+++ b/_webui_collection/DE/Liste_Keyboard_Shortcuts.md
@@ -22,6 +22,8 @@ In metasfresh kannst Du in verschiedenen Kontexten einige Prozesse mithilfe best
 | `Alt + 5` | Dokumentenliste öffnen (Sidebar) ![](assets/Sidebar_Icon_WebUI.png) |
 | `Alt + 6` | Liste der verknüpften Belege öffnen (Sidebar) ![](assets/related_docs_fork.png) |
 | `Alt + 7` | Anhangliste öffnen (Sidebar) ![](assets/Attachment_clip.png) |
+| `Alt + ENTER` | Auswahl öffnen / Anwenden ("Bestätigen") / Filter anwenden |
+| `ESC` | Abbrechen |
 
 ### Kontext: Dokument ([Listenansicht](Ansichten))
 
@@ -44,8 +46,6 @@ In metasfresh kannst Du in verschiedenen Kontexten einige Prozesse mithilfe best
 | `Alt + P` | Druckvorschau öffnen |
 | `Alt + U` | Belegstatus auf "Fertiggestellt" setzen |
 | `Alt + W` | Dokument klonen |
-| `Alt + ENTER` | Auswahl öffnen / Anwenden ("Bestätigen") |
-| `ESC` | Abbrechen |
 
 ### Kontext: Registerkarte (im Dokument)
 

--- a/_webui_collection/EN/Keyboard_shortcuts_reference.md
+++ b/_webui_collection/EN/Keyboard_shortcuts_reference.md
@@ -22,6 +22,8 @@ In metasfresh you can speed up some processes in several contexts by using certa
 | `Alt + 5` | Toggle list of documents (Sidebar) ![](assets/Sidebar_Icon_WebUI.png) |
 | `Alt + 6` | Toggle list of referenced documents (Sidebar) ![](assets/related_docs_fork.png) |
 | `Alt + 7` | Toggle list of attachments (Sidebar) ![](assets/Attachment_clip.png) |
+| `Alt + ENTER` | Open selected / Apply ("Done") / Apply filter |
+| `ESC` | Cancel |
 
 ### Document Context ([list view](ViewModes))
 
@@ -44,8 +46,6 @@ In metasfresh you can speed up some processes in several contexts by using certa
 | `Alt + P` | Open Print Preview |
 | `Alt + U` | Set document status to "Complete" |
 | `Alt + W` | Clone document |
-| `Alt + ENTER` | Open selected / Apply ("Done") |
-| `ESC` | Cancel |
 
 ### Tab Context (in document)
 


### PR DESCRIPTION
moved "alt + enter" and "ESC" from doc context to global and added
comment "apply filter" to command description

(this is about issue #251 )