### PR TITLE
Send all emails to one address (sysconfig)

### DIFF
--- a/_webui_collection/DE/Testing_Emails_an_eine_Adresse.md
+++ b/_webui_collection/DE/Testing_Emails_an_eine_Adresse.md
@@ -1,0 +1,20 @@
+---
+title: Wie richte ich zu Testzwecken eine einzige E-Mail-Adresse für alle ausgehenden Belege ein?
+layout: default
+tags:
+  - E-Mails und ausgehende Belege
+  - Einrichtung
+lang: de
+sequence: 40
+ref: testing_send_emails_to_single_address
+---
+
+## Schritte
+1. [Melde Dich bei metasfresh an](Anmeldung) mit der [Benutzerrolle](NeueBenutzerrolle) „Systemadministrator“.
+1. [Gehe ins Menü](Menu) und öffne das Fenster „Systemkonfigurator“.
+1. [Verwende die Filterfunktion](Filterfunktion) und suche nach der Systemkonfiguration mit dem **Namen** `org.adempiere.user.api.IUserBL.DebugMailTo`.
+1. Öffne den Systemkonfigurationseintrag.
+1. Trage in das Feld **Suchschlüssel** die E-Mail-Adresse ein, an die alle Belege versendet werden sollen.
+ >**Hinweis:** Wird nichts in das Feld eingetragen, werden die E-Mails direkt an die jeweiligen Benutzer gesendet. Die Testmail-Funktion ist somit deaktiviert.
+
+1. [metasfresh speichert automatisch](Speicheranzeige). Die Änderungen sind ab sofort aktiv.

--- a/_webui_collection/EN/Testing_send_emails_to_single_address.md
+++ b/_webui_collection/EN/Testing_send_emails_to_single_address.md
@@ -1,0 +1,20 @@
+---
+title: How do I set up one single email address for all outbound documents for testing purposes?
+layout: default
+tags:
+  - Emails and Outbound Documents
+  - Setup
+lang: en
+sequence: 40
+ref: testing_send_emails_to_single_address
+---
+
+## Steps
+1. [Log in to metasfresh](Login) with the [user role](NewUserRole) "System Administrator".
+1. Open "System Configuration" from the [menu](Menu).
+1. [Use the filter](Filtering_function) and search for the system configuration with the **Name** `org.adempiere.user.api.IUserBL.DebugMailTo`.
+1. Open the system configuration entry.
+1. In the field **Search Key**, enter the email address where all documents shall be sent.
+ >**Note:** If nothing is entered into the field the emails will be sent to the respective users directly. In this case, the testing email feature is deactivated.
+
+1. [metasfresh saves the progress automatically](Saveindicator). The changes apply immediately.


### PR DESCRIPTION
- added doc on sysconfig how to set up one email address for all emails
for testing purposes based on
http://docs.metasfresh.org/howto_collection/Wie_kann_ich_zu_testzwecken_alle_mails_an_eine_email_adresse_schicken.html

(this is about issue #476 )