### PR TITLE
Changes to enforce HTTPS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,7 @@
+title: metasfresh documentation
 name: metasfresh documentation
+email: mail@metasfresh.com
+url: "https://docs.metasfresh.org/"
 
 
 collections:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,10 +3,11 @@
     <head>
         <meta charset="utf-8">
         <title>{{ page.title }}</title>
-		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/css/normalize.css"/>
-		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/css/grid.css"/>
-		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/css/github-markdown.css"/>
-		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/css/styles.css"/>
+		<link rel="canonical" href="{{ site.github.url }}{{ page.url }}" />
+		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/css/normalize.css" />
+		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/css/grid.css" />
+		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/css/github-markdown.css" />
+		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/css/styles.css" />
 		<style>
 			.markdown-body {
 				box-sizing: border-box;


### PR DESCRIPTION
see:
- https://konklone.com/post/github-pages-now-supports-https-so-use-it
- https://help.github.com/en/github/working-with-github-pages/securing-your-github-pages-site-with-https

(this is about issue #493 )