### PR TITLE
Added body CSS 'background-color: #fff'

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,15 +12,7 @@
 		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/vendors/css/ionicons.min.css">
 		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/ressources/css/github-markdown.css" />
 		<link rel="stylesheet" type="text/css" href="{{ site.github.url }}/ressources/css/style.css" />
-		<style>
-			.markdown-body {
-				box-sizing: border-box;
-				min-width: 200px;
-				max-width: 980px;
-				margin: 0 auto;
-				padding: 90px 45px 45px 45px;
-			}
-		</style>
+
     </head>
     <body class="markdown-body">
 

--- a/ressources/css/github-markdown.css
+++ b/ressources/css/github-markdown.css
@@ -1,4 +1,4 @@
-/* 
+/*
 This css file is taken from https://github.com/sindresorhus/github-markdown-css and was released unter the The MIT License:
 
 The MIT License (MIT)
@@ -37,6 +37,12 @@ THE SOFTWARE.
   font-size: 16px;
   line-height: 1.6;
   word-wrap: break-word;
+  box-sizing: border-box;
+  min-width: 200px;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 90px 45px 45px 45px;
+  background-color: #fff;
 }
 
 .markdown-body a {


### PR DESCRIPTION
- moved header CSS for .markdown-body into markdown.css file
- added background-color: #fff (white) ->to make docs appear properly in
lightboxes