### PR TITLE
Proper indentation of code blocks + each code example in its own block for easier copy-pasta

### DIFF
--- a/_support_collection/en/change_language_metasfresh_user.md
+++ b/_support_collection/en/change_language_metasfresh_user.md
@@ -9,29 +9,36 @@ ref: change_language_metasfresh_user
 
 1. [Log in](../../webui_collection/EN/Login) to the system where you want to change the language of your current user session.
 1. Open swagger via
-   ```
-   http://<yourserver:port>/swagger-ui.html#/user-session-rest-controller/setLanguageUsingPUT
-   ```
+    ```
+    https://<yourserver:port>/swagger-ui.html#/user-session-rest-controller/setLanguageUsingPUT
+    ```
 
 1. Click "Try it out".
 1. Enter this code:
-   ```json
-   -- for English
-   {
-       "key": "en_US",
-   "caption": "null"
-   }
-   -- for German
-   {
-       "key": "de_DE",
-   "caption": "null"
-   }
-   -- for Swiss German
-   {
-       "key": "de_CH",
-   "caption": "null"
-   }
-   ```
+
+    ###### for English
+    ```json
+    {
+        "key": "en_US",
+        "caption": "null"
+    }
+    ```
+    
+    ###### for German
+    ```json
+    {
+        "key": "de_DE",
+        "caption": "null"
+    }
+    ```
+    
+    ###### for Swiss German
+    ```json
+    {
+        "key": "de_CH",
+        "caption": "null"
+    }
+    ```
 
 1. Click "Execute".
 


### PR DESCRIPTION
Note: i'm not sure how this looks on our docs page. Maybe we still need to tweak it (for example do not indent the code blocks under each point (1. 2. 3. etc.)

This is how it looks in a github comment (though jekyll might render the text differently):
![image](https://user-images.githubusercontent.com/4482210/90224912-1c62b100-de19-11ea-8038-d0de3521e45a.png)
