### PR TITLE
Updated general product description docs

### DIFF
--- a/_webui_collection/DE/Text_auf_Belege_drucken-Produkt.md
+++ b/_webui_collection/DE/Text_auf_Belege_drucken-Produkt.md
@@ -1,5 +1,5 @@
 ---
-title: Wie erfasse ich eine allgemeine Produktbeschreibung, die auf Belegen erscheint?
+title: Wie erfasse ich eine allgemeine Produktbeschreibung?
 layout: default
 tags:
   - Stammdaten
@@ -11,9 +11,9 @@ ref: print_text_on_documents-product
 ---
 
 ## Überblick
-Der Text einer Produktbeschreibung erscheint auf allen entsprechenden Belegen unterhalb des Produktnamens. Weitere Informationen darüber, wie Du eigenen Text in Belege einfügen kannst, gibt es [hier](Text_auf_Belege_drucken-allgemein).
+Der Text einer Produktbeschreibung erscheint auf Auftragsbestätigungen unterhalb des Produktnamens. Weitere Informationen darüber, wie Du eigenen Text in Belege einfügen kannst, gibt es [hier](Text_auf_Belege_drucken-allgemein).
 
-Du kannst die Produktbeschreibung auch eigenständig in die Sprachen Deiner Geschäftspartner übertragen, damit beim [Drucken von Belegen](PDFVorschau) für fremdsprachige Geschäftspartner automatisch der in deren Sprachen entsprechend verfasste Text auf den Belegen aufgeführt wird. Weitere Informationen darüber, wie Du Dateneinträge mehrsprachig verwalten kannst, gibt es [hier](Mehrsprachige_Datenverwaltung).
+Du kannst die Produktbeschreibung auch eigenständig in die Sprachen Deiner Geschäftspartner übertragen, damit beim [Drucken von Auftragsbestätigungen](PDFVorschau) für fremdsprachige Geschäftspartner automatisch der in deren Sprachen entsprechend verfasste Text auf den Belegen aufgeführt wird. Weitere Informationen darüber, wie Du Dateneinträge mehrsprachig verwalten kannst, gibt es [hier](Mehrsprachige_Datenverwaltung).
 
 ## Schritte
 
@@ -35,4 +35,4 @@ Du kannst die Produktbeschreibung auch eigenständig in die Sprachen Deiner Gesc
 1. [metasfresh speichert automatisch](Speicheranzeige).
 
 ## Beispiel
-![](assets/Text auf Belege drucken - Produkt.gif)
+<kbd><img src="assets/Text auf Belege drucken - Produkt.gif" alt="GIF: Allgemeine Produktbeschreibung erfassen"></kbd>

--- a/_webui_collection/DE/Text_auf_Belege_drucken-allgemein.md
+++ b/_webui_collection/DE/Text_auf_Belege_drucken-allgemein.md
@@ -18,7 +18,7 @@ Diese Texte kannst Du auf verschiedene Art und Weise in metasfresh erfassen. Bei
 
 Auf der folgenden Abbildung eines Angebots werden die modifizierbaren Textstellen hervorgehoben sowie die jeweiligen Menüpunkte aufgezeigt, wo sie in metasfresh bearbeitet werden können:
 
-![Modifizierbare Belegtexte mit den jeweiligen Menüpunkten](assets/Text auf Belege drucken.png)
+<kbd><img src="assets/Text auf Belege drucken.png" alt="Abb.: Modifizierbare Belegtexte mit den jeweiligen Menüpunkten"></kbd>
 
 ---
 
@@ -39,10 +39,10 @@ Klicke [hier](Text_auf_Belege_drucken-Belegart), wenn Du am Anfang und Ende des 
 ## Produkte
 
 #### Partnerspezifische Produkte verwalten
-Klicke [hier](Partnerspezifische_Produkte), wenn Du partnerspezifische Produktnamen und -nummern erfassen möchtest, die anstelle Deiner intern verwendeten Namen und Nummern auf den Belegen der jeweiligen Geschäftspartner erscheinen.
+Klicke [hier](Partnerspezifische_Produkte), wenn Du partnerspezifische Produktnamen und -nummern erfassen möchtest, die anstelle der von Dir intern verwendeten Namen und Nummern auf den Belegen der jeweiligen Geschäftspartner erscheinen.
 
 #### Allgemeine Produktbeschreibung hinzufügen
-Klicke [hier](Text_auf_Belege_drucken-Produkt), wenn Du einem Produkt eine allgemeine Beschreibung hinzufügen möchtest, die auf allen Belegen erscheint.
+Klicke [hier](Text_auf_Belege_drucken-Produkt), wenn Du einem Produkt eine allgemeine Beschreibung hinzufügen möchtest.
 
 #### Auftragszeilenspezifische Produktbeschreibung hinzufügen
 Klicke [hier](Auftragszeilenspezifische_Produktbeschreibung), wenn Du einem Produkt eine Beschreibung hinzufügen möchtest, die ausschließlich auf der jeweiligen Auftragsbestätigung erscheint.

--- a/_webui_collection/EN/Print_text_on_documents-general.md
+++ b/_webui_collection/EN/Print_text_on_documents-general.md
@@ -18,7 +18,7 @@ You can record these texts in metasfresh in a number of different ways. Upon doc
 
 The following figure of a quotation highlights the modifiable text passages and points out the menu items where they can be edited in metasfresh:
 
-![Modifiable document texts with their respective menu items](assets/Text on documents.png)
+<kbd><img src="assets/Text on documents.png" alt="Fig.: Modifiable document texts with their respective menu items"></kbd>
 
 ---
 
@@ -42,7 +42,7 @@ Click [here](Print_text_on_documents-doctype), if you want to add a text at the 
 Click [here](Partner-specific_products), if you want to record partner-specific product names and numbers that will appear on the documents of the respective business partners instead of the names and numbers you use for internal product management purposes.
 
 #### Add a general product description
-Click [here](Print_text_on_documents-product), if you want to add a general product description that will appear on all documents.
+Click [here](Print_text_on_documents-product), if you want to add a general product description.
 
 #### Add an order line-specific product description
 Click [here](Order_line-specific_product_description), if you want to add a product description that will appear on the respective order confirmation only.

--- a/_webui_collection/EN/Print_text_on_documents-product.md
+++ b/_webui_collection/EN/Print_text_on_documents-product.md
@@ -1,5 +1,5 @@
 ---
-title: How do I record a general product description that will appear on documents?
+title: How do I record a general product description?
 layout: default
 tags:
   - Master Data
@@ -11,9 +11,9 @@ ref: print_text_on_documents-product
 ---
 
 ## Overview
-The product description text will appear below the product name on all corresponding documents. For additional information on how to place manual text on documents, please see [here](Print_text_on_documents-general).
+The product description text will appear below the product name on sales order confirmations. For additional information on how to place manual text on documents, please see [here](Print_text_on_documents-general).
 
-You can also autonomously transfer the product description into the languages of your business partners, so that when you [print commercial documents](PrintPreview) for foreign business partners, the text will automatically appear on these documents in their respective languages. For additional information on how to manage data entries in multiple languages, please see [here](Multilingual_data_management).
+You can also translate the product description yourself into the languages of your business partners, so that when you [print sales order confirmations](PrintPreview) for foreign business partners, the text will automatically appear on these documents in their respective languages. For additional information on how to manage data entries in multiple languages, please see [here](Multilingual_data_management).
 
 ## Steps
 
@@ -35,4 +35,4 @@ You can also autonomously transfer the product description into the languages of
 1. [metasfresh saves the progress automatically](Saveindicator).
 
 ## Example
-![](assets/Text on documents - product.gif)
+<kbd><img src="assets/Text on documents - product.gif" alt="GIF: How to record a general product description"></kbd>


### PR DESCRIPTION
- product descriptions appear on sales order confirmations only ->
corrected instructions
(this is about issue #377 )