### PR TITLE
JasperReports entry does not make sense

### DIFF
--- a/_howto_collection/EN/metasfresh_architecture.md
+++ b/_howto_collection/EN/metasfresh_architecture.md
@@ -17,7 +17,7 @@ lang: en
 | WebAPI | Java 8 | Spring Boot | REST, JSON, Swagger, Spring, hazelcast, websocket |
 | App | Java 8, SQL | Spring Boot | Jasper Reports, Application Dictionary |
 | DB | SQL, PgSQL | Postgres (9.5+) | Application Dictionary |
-| Reporting | JRXML | Jasperserver | Jasper Reports 6.5.1 <a href="https://community.jaspersoft.com/project/jaspersoft-studio/releases#project_releases-old-1" title="Jaspersoft® Studio" target="\_blank">Client</a> |
+| Reporting | JRXML | Jasperserver | Java Rest Client for JasperReports Server |
 | elastic Search |  |  | Standard Elastic Search |
 | RabbitMQ |  |  |Standard RabbitMQ |
 | Java Client | Java 8 | Java JRE 8+ | Swing |


### PR DESCRIPTION
 Jasper Reports 6.5.1 <a href="https://community.jaspersoft.com/project/jaspersoft-studio/releases#project_releases-old-1" title="Jaspersoft® Studio" target="\_blank">Client</a> 

The description seems to be wrong: it should either link to the [Rest Java Client](https://github.com/Jaspersoft/jrs-rest-java-client) (like the text Says)
Or refer to [Jaspersoft® Studio](https://community.jaspersoft.com/project/jaspersoft-studio/releases) (which is only for editing and deploying the Reports)