### PR TITLE
Update url in doc about Maven settings - followup

### DIFF
--- a/_developers_collection/en/getting_started_maven_settings.md
+++ b/_developers_collection/en/getting_started_maven_settings.md
@@ -9,4 +9,4 @@ ref: developers_getting_started_mvn_settings
 ---
 
 Here is a simple `settings.xml` file that you might want to place in your Maven `.m2` folder.
-It makes sure that Maven knows about our Maven repository: <a href="https://github.com/metasfresh/metasfresh/blob/3bcd7fba90c46d6c2e5ecf52168b72d0c17591f2/misc/dev-support/maven/settings.xml#L28" title="metasfresh Maven settings.xml | github.com" target="\_blank">View XML file</a>.
+It makes sure that Maven knows about our Maven repository: <a href="https://github.com/metasfresh/metasfresh/blob/master/misc/dev-support/maven/settings.xml" title="metasfresh Maven settings.xml | github.com" target="\_blank">View XML file</a>.


### PR DESCRIPTION
The previous url included the commit's hash code instead of `master`.
(this is about issue #377)